### PR TITLE
chore: configure trusted publishing for npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,9 +41,8 @@ jobs:
           git config user.email "actions@github.com"
           git push --follow-tags
       - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v2
+        uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           package: package.json
       - name: 'Get release tag'
         uses: 'WyriHaximus/github-action-get-previous-tag@v1'


### PR DESCRIPTION
Updating to trusted publishing based on the following instructions
- https://docs.npmjs.com/trusted-publishers
- https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#github-action